### PR TITLE
Added example setup for Grafana 9.5 and InfluxDB 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@
 
 ## Demo
 [![analyze trends](https://img.youtube.com/vi/US_zgCYP0lE/0.jpg)](https://youtu.be/US_zgCYP0lE)
+
+## Example 
+[Example with Grafana 9.5 / InfluxDb 2.7 and docker-compose](./example/readme.md)

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3'
+services:
+  influxdb:
+    image: influxdb:2.7
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: superuser
+      DOCKER_INFLUXDB_INIT_PASSWORD: Passw0rd!
+      DOCKER_INFLUXDB_INIT_ORG: MyOrg
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: N3Z_uUDSQ61qVp93K5dNzH3rbNcKxtphDLrjfS_DcX2cdTr3nR2pOlixGCx6HQ8VI66nqnyztOlPFoWFXoe62Q==
+      DOCKER_INFLUXDB_INIT_BUCKET: NBomber
+    ports:
+      - 8086:8086
+    volumes:
+    - influxdb-data:/var/lib/influxdb2
+
+  grafana:
+    image: grafana/grafana-oss:9.5.3
+    ports:
+      - 3000:3000
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+  
+volumes:
+  influxdb-data:

--- a/example/grafana/provisioning/dashboards/dashboard.yml
+++ b/example/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+- name: 'NBomber'
+  orgId: 1
+  folder: ''
+  type: file
+  disableDeletion: false
+  editable: true
+  options:
+    path: /etc/grafana/provisioning/dashboards

--- a/example/grafana/provisioning/dashboards/nbomber_board.json
+++ b/example/grafana/provisioning/dashboards/nbomber_board.json
@@ -1,0 +1,3273 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 97,
+      "options": {
+        "displayMode": "lcd",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "text": {},
+        "valueMode": "color"
+      },
+      "pluginVersion": "9.5.2",
+      "targets": [
+        {
+          "alias": "Node count",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(\"cluster.node_count\") as \"node count\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"current_operation\" = 'bombing') GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "node_count",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "CPU count",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "nbomber",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(\"cluster.node_cpu_count\") as \"cpu count\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"current_operation\" = 'bombing') GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "cores_count",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "cluster_node"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Cluster Info",
+      "transformations": [
+        {
+          "id": "groupBy",
+          "options": {}
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "cpu count": "CPU count",
+              "node count": "Node count"
+            }
+          }
+        }
+      ],
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "description": "It displays stats only for current_operation = complete",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status code"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 121
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "count"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 139
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 46,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "9.5.2",
+      "targets": [
+        {
+          "datasource": "${DS_INFLUXDB}",
+          "groupBy": [
+            {
+              "params": [
+                "status_code"
+              ],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "nbomber",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"status_code.count\") as \"count\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"current_operation\" = 'complete') GROUP BY time(1d), \"scenario\", \"status_code.status\"",
+          "rawQuery": true,
+          "refId": "count",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "status_code.count"
+                ],
+                "type": "field"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "status_code.is_error"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "test_suite",
+              "operator": "=~",
+              "value": "/^$test_suite$/"
+            },
+            {
+              "condition": "AND",
+              "key": "test_name",
+              "operator": "=~",
+              "value": "/^$test_name$/"
+            },
+            {
+              "condition": "AND",
+              "key": "scenario",
+              "operator": "=~",
+              "value": "/^$scenario$/"
+            },
+            {
+              "condition": "AND",
+              "key": "step",
+              "operator": "=~",
+              "value": "/^$step$/"
+            },
+            {
+              "condition": "AND",
+              "key": "operation",
+              "operator": "=",
+              "value": "complete"
+            }
+          ]
+        }
+      ],
+      "title": "scenario status codes",
+      "transformations": [
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Time": {
+                "aggregations": []
+              },
+              "count": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "nbomber.is error {scenario: http_scenario, status_code.status: -101}": {
+                "aggregations": [
+                  "last"
+                ]
+              },
+              "nbomber.is error {scenario: http_scenario, status_code.status: OK}": {
+                "aggregations": []
+              },
+              "scenario": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "status_code.status": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "count": "",
+              "status_code.status": "status"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "influxdb",
+        "uid": "jBqDkjlnk"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 4,
+      "panels": [],
+      "repeat": "scenario",
+      "title": "$scenario",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false,
+            "minWidth": 40
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "request count"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 120
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "scenario"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "step"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "load value"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 78,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "9.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"simulation.value\") as \"load value\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "load_value",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(\"ok.request.count\") as \"request count\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "req count",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.request.rps\") as \"rps\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "rps",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.latency.min\") as \"min\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "min",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.latency.mean\") as \"mean\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "mean",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.latency.max\") as \"max\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "max",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.latency.percent50\") as \"p50\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "p50",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.latency.percent75\") as \"p75\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "p75",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.latency.percent95\") as \"p95\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "p95",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.latency.percent99\") as \"p99\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "p99",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.latency.stddev\") as \"stddev\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "stddev",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.datatransfer.min\") as \"data_min\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "data_min",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.datatransfer.mean\") as \"data_mean\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1m), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "data_mean",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.datatransfer.max\") as \"data_max\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1m), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "data_max",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.datatransfer.all\") as \"data_all\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1m), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "data_all",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "OK Stats",
+      "transformations": [
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "data_all": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "data_max": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "data_mean": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "data_min": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "load value": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "max": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "mean": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "min": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "p50": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "p75": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "p95": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "p99": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "request count": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "rps": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "scenario": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "stddev": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "step": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "data_all (lastNotNull)": 16,
+              "data_max (lastNotNull)": 15,
+              "data_mean (lastNotNull)": 14,
+              "data_min (lastNotNull)": 13,
+              "load value (lastNotNull)": 2,
+              "max (lastNotNull)": 7,
+              "mean (lastNotNull)": 6,
+              "min (lastNotNull)": 5,
+              "p50 (lastNotNull)": 8,
+              "p75 (lastNotNull)": 9,
+              "p95 (lastNotNull)": 10,
+              "p99 (lastNotNull)": 11,
+              "request count (lastNotNull)": 3,
+              "rps (lastNotNull)": 4,
+              "scenario": 0,
+              "stddev (lastNotNull)": 12,
+              "step": 1
+            },
+            "renameByName": {
+              "data_all (lastNotNull)": "data all",
+              "data_max (lastNotNull)": "data max",
+              "data_mean (lastNotNull)": "data mean",
+              "data_min (lastNotNull)": "data min",
+              "load value (lastNotNull)": "load value",
+              "max (lastNotNull)": "max (ms)",
+              "mean (lastNotNull)": "mean (ms)",
+              "min (last)": "min",
+              "min (lastNotNull)": "min (ms)",
+              "p50 (lastNotNull)": "p50 (ms)",
+              "p75 (lastNotNull)": "p75 (ms)",
+              "p95 (lastNotNull)": "p95 (ms)",
+              "p99 (lastNotNull)": "p99 (ms)",
+              "request count (lastNotNull)": "request count",
+              "rps (lastNotNull)": "RPS",
+              "scenario": "",
+              "stddev (lastNotNull)": "StdDev",
+              "step": ""
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 108,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "ok RPS",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "nbomber",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.request.rps\") FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1s) fill(none)",
+          "rawQuery": true,
+          "refId": "ok_rps",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "fail RPS",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"fail.request.rps\") FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1s) fill(none)",
+          "rawQuery": true,
+          "refId": "fail_rps",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "load",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"simulation.value\") FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1s) fill(none)",
+          "rawQuery": true,
+          "refId": "load",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "description": "It displays stats only for current_operation = complete",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "t > 800 and t < 1200"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "yellow",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "t >= 1200"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 44,
+      "options": {
+        "displayMode": "basic",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "pluginVersion": "9.5.2",
+      "targets": [
+        {
+          "alias": "t <= 800",
+          "datasource": "${DS_INFLUXDB}",
+          "groupBy": [],
+          "hide": false,
+          "measurement": "nbomber",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"latency_count.less_or_eq_800\") FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"current_operation\" = 'complete') GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "latency_count.less_or_eq_800"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "test_suite",
+              "operator": "=~",
+              "value": "/^$test_suite$/"
+            },
+            {
+              "condition": "AND",
+              "key": "test_name",
+              "operator": "=~",
+              "value": "/^$test_name$/"
+            },
+            {
+              "condition": "AND",
+              "key": "scenario",
+              "operator": "=~",
+              "value": "/^$scenario$/"
+            },
+            {
+              "condition": "AND",
+              "key": "step",
+              "operator": "=~",
+              "value": "/^$step$/"
+            },
+            {
+              "condition": "AND",
+              "key": "operation",
+              "operator": "=",
+              "value": "complete"
+            }
+          ]
+        },
+        {
+          "alias": "t > 800 and t < 1200",
+          "datasource": "${DS_INFLUXDB}",
+          "groupBy": [],
+          "hide": false,
+          "measurement": "nbomber",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"latency_count.more_800_less_1200\") FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"current_operation\" = 'complete') GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "latency_count.more_800_less_1200"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "test_suite",
+              "operator": "=~",
+              "value": "/^$test_suite$/"
+            },
+            {
+              "condition": "AND",
+              "key": "test_name",
+              "operator": "=~",
+              "value": "/^$test_name$/"
+            },
+            {
+              "condition": "AND",
+              "key": "scenario",
+              "operator": "=~",
+              "value": "/^$scenario$/"
+            },
+            {
+              "condition": "AND",
+              "key": "step",
+              "operator": "=~",
+              "value": "/^$step$/"
+            },
+            {
+              "condition": "AND",
+              "key": "operation",
+              "operator": "=",
+              "value": "complete"
+            }
+          ]
+        },
+        {
+          "alias": "t >= 1200",
+          "datasource": "${DS_INFLUXDB}",
+          "groupBy": [],
+          "hide": false,
+          "measurement": "nbomber",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"latency_count.more_or_eq_1200\") FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"current_operation\" = 'complete') GROUP BY time(1d)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "latency_count.more_or_eq_1200"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "test_suite",
+              "operator": "=~",
+              "value": "/^$test_suite$/"
+            },
+            {
+              "condition": "AND",
+              "key": "test_name",
+              "operator": "=~",
+              "value": "/^$test_name$/"
+            },
+            {
+              "condition": "AND",
+              "key": "scenario",
+              "operator": "=~",
+              "value": "/^$scenario$/"
+            },
+            {
+              "condition": "AND",
+              "key": "step",
+              "operator": "=~",
+              "value": "/^$step$/"
+            },
+            {
+              "condition": "AND",
+              "key": "operation",
+              "operator": "=",
+              "value": "complete"
+            }
+          ]
+        }
+      ],
+      "title": "Scenario latency indicators",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "id": 119,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "min",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.latency.min\") FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" = 'global information' AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1s) fill(none)",
+          "rawQuery": true,
+          "refId": "min",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "max",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.latency.max\") FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" = 'global information' AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1s) fill(none)",
+          "rawQuery": true,
+          "refId": "max",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "p50",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.latency.percent50\") FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" = 'global information' AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1s) fill(none)",
+          "rawQuery": true,
+          "refId": "p50",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "p99",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.latency.percent99\") FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" = 'global information' AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1s) fill(none)",
+          "rawQuery": true,
+          "refId": "p99",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 120,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "ok RPS",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "nbomber",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"ok.request.rps\") FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" = 'global information' AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1s) fill(none)",
+          "rawQuery": true,
+          "refId": "ok_rps",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "fail RPS",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"fail.request.rps\") FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" = 'global information' AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1s) fill(none)",
+          "rawQuery": true,
+          "refId": "fail_rps",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "load",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"simulation.value\") FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" = 'global information' AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1s) fill(none)",
+          "rawQuery": true,
+          "refId": "load",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Data transfer",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "filterable": false,
+            "inspect": false,
+            "minWidth": 40
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "scenario"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "step"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "request count"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 93,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "9.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(\"fail.request.count\") as \"request count\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "req count",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"fail.request.rps\") as \"rps\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "rps",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"fail.latency.min\") as \"min\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "min",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"fail.latency.mean\") as \"mean\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "mean",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"fail.latency.max\") as \"max\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "max",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"fail.latency.percent50\") as \"p50\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "p50",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"fail.latency.percent75\") as \"p75\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "p75",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"fail.latency.percent95\") as \"p95\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "p95",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"fail.latency.percent99\") as \"p99\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "p99",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"fail.latency.stddev\") as \"stddev\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "stddev",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"fail.datatransfer.min\") as \"data_min\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "data_min",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"fail.datatransfer.mean\") as \"data_mean\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "data_mean",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"fail.datatransfer.max\") as \"data_max\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "data_max",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"fail.datatransfer.all\") as \"data_all\" FROM \"nbomber\" WHERE (\"session_id\" =~ /^$session_id$/ AND \"cluster_id\" =~ /^$cluster_id$/ AND \"test_suite\" =~ /^$test_suite$/ AND \"test_name\" =~ /^$test_name$/ AND \"scenario\" =~ /^$scenario$/ AND \"step\" =~ /^$step$/ AND \"current_operation\" =~ /^$current_operation$/) AND $timeFilter GROUP BY time(1d), \"step\", \"scenario\"",
+          "rawQuery": true,
+          "refId": "data_all",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "FAIL Stats",
+      "transformations": [
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "data_all": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "data_max": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "data_mean": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "data_min": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "max": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "mean": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "min": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "p50": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "p75": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "p95": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "p99": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "request count": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "rps": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "scenario": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "stddev": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "step": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "data_all (lastNotNull)": "data all",
+              "data_max (lastNotNull)": "data max",
+              "data_mean (lastNotNull)": "data mean",
+              "data_min (lastNotNull)": "data min",
+              "max (lastNotNull)": "max (ms)",
+              "mean (lastNotNull)": "mean (ms)",
+              "min (last)": "min",
+              "min (lastNotNull)": "min (ms)",
+              "p50 (lastNotNull)": "p50 (ms)",
+              "p75 (lastNotNull)": "p75 (ms)",
+              "p95 (lastNotNull)": "p95 (ms)",
+              "p99 (lastNotNull)": "p99 (ms)",
+              "request count (lastNotNull)": "request count",
+              "rps (lastNotNull)": "RPS",
+              "stddev (lastNotNull)": "StdDev",
+              "step": ""
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "isNone": true,
+          "selected": false,
+          "text": "None",
+          "value": ""
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "${DS_INFLUXDB}"
+        },
+        "definition": "SELECT \"session_id\" from \"nbomber\"",
+        "hide": 0,
+        "includeAll": false,
+        "label": "session id",
+        "multi": false,
+        "name": "session_id",
+        "options": [],
+        "query": "SELECT \"session_id\" from \"nbomber\"",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "isNone": true,
+          "selected": false,
+          "text": "None",
+          "value": ""
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "${DS_INFLUXDB}"
+        },
+        "definition": "SHOW TAG VALUES with KEY = \"cluster_id\"",
+        "hide": 0,
+        "includeAll": false,
+        "label": "cluster id",
+        "multi": false,
+        "name": "cluster_id",
+        "options": [],
+        "query": "SHOW TAG VALUES with KEY = \"cluster_id\"",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "isNone": true,
+          "selected": false,
+          "text": "None",
+          "value": ""
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "${DS_INFLUXDB}"
+        },
+        "definition": "SHOW TAG VALUES with KEY = \"test_suite\" WHERE cluster_id =~ /^$cluster_id$/",
+        "hide": 0,
+        "includeAll": false,
+        "label": "test suite",
+        "multi": false,
+        "name": "test_suite",
+        "options": [],
+        "query": "SHOW TAG VALUES with KEY = \"test_suite\" WHERE cluster_id =~ /^$cluster_id$/",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "isNone": true,
+          "selected": false,
+          "text": "None",
+          "value": ""
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "${DS_INFLUXDB}"
+        },
+        "definition": "SHOW TAG VALUES with KEY = \"test_name\" WHERE cluster_id =~ /^$cluster_id$/ AND test_suite =~ /^$test_suite$/",
+        "hide": 0,
+        "includeAll": false,
+        "label": "test name",
+        "multi": false,
+        "name": "test_name",
+        "options": [],
+        "query": "SHOW TAG VALUES with KEY = \"test_name\" WHERE cluster_id =~ /^$cluster_id$/ AND test_suite =~ /^$test_suite$/",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": [
+            "bombing"
+          ],
+          "value": [
+            "bombing"
+          ]
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "current operation",
+        "multi": true,
+        "name": "current_operation",
+        "options": [
+          {
+            "selected": false,
+            "text": "warmup",
+            "value": "warmup"
+          },
+          {
+            "selected": true,
+            "text": "bombing",
+            "value": "bombing"
+          },
+          {
+            "selected": false,
+            "text": "complete",
+            "value": "complete"
+          }
+        ],
+        "query": "warmup, bombing, complete",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "${DS_INFLUXDB}"
+        },
+        "definition": "SHOW TAG VALUES with KEY = \"scenario\" WHERE cluster_id =~ /^$cluster_id$/ AND test_suite =~ /^$test_suite$/ AND test_name =~ /^$test_name$/",
+        "hide": 0,
+        "includeAll": true,
+        "label": "scenario",
+        "multi": true,
+        "name": "scenario",
+        "options": [],
+        "query": "SHOW TAG VALUES with KEY = \"scenario\" WHERE cluster_id =~ /^$cluster_id$/ AND test_suite =~ /^$test_suite$/ AND test_name =~ /^$test_name$/",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "${DS_INFLUXDB}"
+        },
+        "definition": "SHOW TAG VALUES with KEY = \"step\" WHERE cluster_id =~ /^$cluster_id$/ AND test_suite =~ /^$test_suite$/ AND test_name =~ /^$test_name$/ AND scenario =~ /^$scenario$/",
+        "hide": 0,
+        "includeAll": true,
+        "label": "step",
+        "multi": true,
+        "name": "step",
+        "options": [],
+        "query": "SHOW TAG VALUES with KEY = \"step\" WHERE cluster_id =~ /^$cluster_id$/ AND test_suite =~ /^$test_suite$/ AND test_name =~ /^$test_name$/ AND scenario =~ /^$scenario$/",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "hide": 2,
+        "name": "DS_INFLUXDB",
+        "query": "influxdb",
+        "skipUrlSync": false,
+        "type": "constant"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-8h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "NBomber",
+  "uid": "nbomber",
+  "version": 1,
+  "weekStart": ""
+}

--- a/example/grafana/provisioning/dashboards/nbomber_sessions_board.json
+++ b/example/grafana/provisioning/dashboards/nbomber_sessions_board.json
@@ -1,0 +1,284 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Session ID"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "",
+                    "url": "/d/nbomber/nbomber?var-cluster_id=${__data.fields[\"Cluster ID\"]}&var-test_suite=${__data.fields[\"Test Suite\"]}&var-test_name=${__data.fields[\"Test Name\"]}&var-session_id=${__value.raw}﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿&﻿var-current_operation=﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿${__data.fields[\"Current Operation\"]}﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿&from=﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿${__from}﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿&to=now&refresh=5s"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Current Operation"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "bombing": {
+                        "color": "blue",
+                        "index": 0,
+                        "text": "bombing"
+                      },
+                      "complete": {
+                        "color": "green",
+                        "index": 1,
+                        "text": "complete"
+                      },
+                      "init": {
+                        "color": "purple",
+                        "index": 2,
+                        "text": "init"
+                      },
+                      "stop": {
+                        "color": "red",
+                        "index": 3,
+                        "text": "stop"
+                      },
+                      "warmup": {
+                        "color": "yellow",
+                        "index": 4,
+                        "text": "warmup"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 20,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Session ID"
+          }
+        ]
+      },
+      "pluginVersion": "9.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "nbomber",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT \"session_id\", \"current_operation\" FROM \"nbomber\" WHERE $timeFilter GROUP BY \"cluster_id\", \"test_suite\", \"test_name\"",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "session_id"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "NBomber Sessions",
+      "transformations": [
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "cluster_id": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "current_operation": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "node_current_operation": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "session_id": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "test_name": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "test_suite": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "cluster_id": 2,
+              "current_operation (lastNotNull)": 1,
+              "session_id": 0,
+              "test_name": 4,
+              "test_suite": 3
+            },
+            "renameByName": {
+              "cluster_id": "Cluster ID",
+              "current_operation": "Current Operation",
+              "current_operation (lastNotNull)": "Current Operation",
+              "node_current_operation (lastNotNull)": "Current Operation",
+              "session_id": "Session ID",
+              "test_name": "Test Name",
+              "test_suite": "Test Suite"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "hide": 2,
+        "name": "DS_INFLUXDB",
+        "query": "influxdb",
+        "skipUrlSync": false,
+        "type": "constant"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-8h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "NBomber Sessions",
+  "uid": "nbomber_sessions",
+  "version": 1,
+  "weekStart": ""
+}

--- a/example/grafana/provisioning/datasources/influxdb_datasource.yml
+++ b/example/grafana/provisioning/datasources/influxdb_datasource.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: influxdb
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    jsonData:
+      dbName: NBomber
+      httpMode: GET
+      httpHeaderName1: 'Authorization'
+    secureJsonData:
+      httpHeaderValue1: 'Token N3Z_uUDSQ61qVp93K5dNzH3rbNcKxtphDLrjfS_DcX2cdTr3nR2pOlixGCx6HQ8VI66nqnyztOlPFoWFXoe62Q=='

--- a/example/readme.md
+++ b/example/readme.md
@@ -1,0 +1,38 @@
+# Grafana dashboards with Influx DB and docker compose
+
+This example demonstrates how to quickly set up a demo environment with Grafana 9.5 and InfluxDB 2.7 using docker compose.
+
+## Give it a try!
+Navigate to `./example` and type
+```
+docker-compose up -d
+```
+
+Go to http://localhost:8086/ to check if InfluxDB has started and was configured correctly. Use `superuser` and `Passw0rd!`to log in. You should see the organization `MyOrg` (unless you have changed that in the docker-compose file) and a bucket named `NBomber`
+
+Next, go to http://localhost:3000 to log in into Grafana. The initial user-name/password is `admin` / `admin`.  
+
+The data source and the dashboards are automatically provisioned and should work out of the box.
+
+## Warning
+**Do not use this setup in a production environment!**  
+At the very least, change the passwords and the InfluxDB token to something unique!  
+Better yet, create an InfluxDB token with fewer privileges (e.g. read-only) and use this token for the Grafana data source.
+
+## Sending data from NBomber tests
+In order to send data from you NBomber tests to InfluxDB, use the following settings in `infra-config.yaml`
+
+```json
+{
+  "InfluxDBSink": {
+    "Url": "http://localhost:8086?org=MyOrg&bucket=NBomber",
+    "Token": "N3Z_uUDSQ61qVp93K5dNzH3rbNcKxtphDLrjfS_DcX2cdTr3nR2pOlixGCx6HQ8VI66nqnyztOlPFoWFXoe62Q==",
+    "CustomTags": [
+      {
+        "Key": "environment",
+        "Value": "linux"
+      }
+    ]
+  }
+}
+```


### PR DESCRIPTION
When testing the InfluxDB sink and the Grafana dashboards, I found that the dashboards had a few issues after they were converted to the new schema upon import into Grafana. While fixing these issues, I wanted to create a self-contained demo setup using docker-compose and the auto-provisioning feature of Grafana and this is what I came up with.

The setup in the `./example` folder contains:
* a docker compose file that 
  * sets up InfluxDb 2.7 with credentials and an initial organization and bucket
  * sets up Grafana 9.5 with auto-provisioned datasource and NBomber dashboards

The dashboards are the same as the ones in the root directory of this repo, except that they were converted to a newer schema by Grafana upon import. Seems like during this conversion, a few variables and queries were lost which I manually re-added so that everything works as before.

Would you like to keep the older dashboard files in the root? If yes, it might be a good idea to mention their Grafana version in the readme.